### PR TITLE
Testing IgnoreURL Change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@sector-labs/seo-slip",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@sector-labs/seo-slip",
-            "version": "1.0.9",
+            "version": "1.0.10",
             "license": "MIT",
             "dependencies": {
                 "csv-parse": "^4.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sector-labs/seo-slip",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "description": "Catches SEO regressions by sampling and checking a website against a set of rules",
     "main": "index.js",
     "scripts": {

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -43,10 +43,11 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
     crawler.httpsAgent = https.Agent({ keepAlive: true });
 
     const skipUrls = (variables.skipUrls || []).map((str) => new RegExp(str));
+
     crawler.addFetchCondition((queueItem, referrerQueueItem, callback) => {
         if (queueItem === referrerQueueItem) {
-            const fetch = false
-            callback(null, fetch)
+            const fetch = false;
+            callback(null, fetch);
         } else {
             const fetch = !skipUrls.some((skipUrl) => skipUrl.test(queueItem.url));
             callback(null, fetch);

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -105,7 +105,7 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
             .map((checker) => checker.shouldStop(queueItem))
             .some((shouldStop) => shouldStop);
         if (stop) {
-            crawler.stop();
+            crawler.stop(true);
             crawlCompleted();
         }
     };

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -128,6 +128,8 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
         console.log(`fetch for url=${queueItem.url} client fetch error: ${error}`)
     );
 
+    crawler.on('crawlstart', (queueItem) => console.log(queueItem));
+
     const originalEmit = crawler.emit;
     crawler.emit = function (evtName, queueItem) {
         crawler.queue.countItems({ fetched: true }, function (err, completeCount) {

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -150,11 +150,11 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
                     length,
                     crawler._openRequests.length,
                     crawler._openListeners,
-                    queueItem.url,
-                    queueItem.status,
-                    queueItem.fetched,
-                    queueItem.stateData.code,
-                    queueItem.referrer
+                    queueItem?.url ?? queueItem,
+                    queueItem?.status ?? queueItem,
+                    queueItem?.fetched ?? queueItem,
+                    queueItem?.stateData.code ?? queueItem,
+                    queueItem?.referrer ?? queueItem
                 );
             });
         });

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -128,7 +128,7 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
         console.log(`fetch for url=${queueItem.url} client fetch error: ${error}`)
     );
 
-    crawler.on('crawlstart', console.log(crawler.initialURL));
+    crawler.on('crawlstart', () => console.log(crawler.initialURL));
 
     const originalEmit = crawler.emit;
     crawler.emit = function (evtName, queueItem) {

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -143,18 +143,20 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
                     throw err;
                 }
 
+                const keys = Object.keys(crawler.queue);
+
                 console.log(
                     'fetched %d of %d — %d open requests, %d open listeners',
                     completeCount,
                     length,
                     crawler._openRequests.length,
                     crawler._openListeners,
-                    queueItem?.url ?? queueItem,
-                    queueItem?.status ?? queueItem,
-                    queueItem?.fetched ?? queueItem,
-                    queueItem?.stateData.code ?? queueItem,
-                    queueItem?.referrer ?? queueItem,
-                    crawler.queue[-3]
+                    keys
+                        .slice(-4)
+                        .slice(0, 3)
+                        .forEach((element) => {
+                            crawler.queue.get(element, (err, queueItem) => console.log(queueItem));
+                        })
                 );
             });
         });

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -134,7 +134,9 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
 
     crawler.on('discoverycomplete', () => {
         console.log('____________');
-        console.log(crawler.queue);
+        crawler.queue.forEach((element) => {
+            console.log(`${element.url} - ${element.fetched} - ${element.status}`);
+        });
         console.log('____________');
     });
 

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -45,7 +45,7 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
     const skipUrls = (variables.skipUrls || []).map((str) => new RegExp(str));
 
     crawler.addFetchCondition((queueItem, referrerQueueItem, callback) => {
-        if (queueItem.url === referrerQueueItem.url) {
+        if (queueItem.referrer === undefined) {
             console.log('Skipped same URL!');
             const fetch = false;
             callback(null, fetch);

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -45,7 +45,8 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
     const skipUrls = (variables.skipUrls || []).map((str) => new RegExp(str));
 
     crawler.addFetchCondition((queueItem, referrerQueueItem, callback) => {
-        if (queueItem === referrerQueueItem) {
+        if (queueItem.url === referrerQueueItem.url) {
+            console.log('Skipped same URL!');
             const fetch = false;
             callback(null, fetch);
         } else {

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -3,6 +3,9 @@ const https = require('https');
 
 const Crawler = require('simplecrawler');
 
+let crawlStarts = 0;
+let crawlStops = 0;
+
 const {
     newEmptyAnalysis,
     newEmptyAnalyses,
@@ -129,7 +132,12 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
     );
 
     crawler.on('crawlstart', () => {
-        console.log(crawler.initialURL);
+        crawlStarts += 1;
+    });
+
+    crawler.on('complete', () => {
+        crawlStops += 1;
+        crawlCompleted;
     });
 
     const originalEmit = crawler.emit;
@@ -154,7 +162,8 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
                     queueItem?.status ?? queueItem,
                     queueItem?.fetched ?? queueItem,
                     queueItem?.stateData.code ?? queueItem,
-                    queueItem?.referrer ?? queueItem
+                    queueItem?.referrer ?? queueItem,
+                    crawler.queue[-3]
                 );
             });
         });
@@ -162,8 +171,6 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
         console.log(evtName, queueItem ? (queueItem.url ? queueItem.url : queueItem) : null);
         originalEmit.apply(crawler, arguments);
     };
-
-    crawler.on('complete', crawlCompleted);
 
     Promise.all(
         checkers

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -132,14 +132,6 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
         console.log(crawler.initialURL);
     });
 
-    crawler.on('discoverycomplete', () => {
-        console.log('____________');
-        crawler.queue.forEach((element) => {
-            console.log(`${element.url} - ${element.fetched} - ${element.status}`);
-        });
-        console.log('____________');
-    });
-
     const originalEmit = crawler.emit;
     crawler.emit = function (evtName, queueItem) {
         crawler.queue.countItems({ fetched: true }, function (err, completeCount) {
@@ -157,7 +149,12 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
                     completeCount,
                     length,
                     crawler._openRequests.length,
-                    crawler._openListeners
+                    crawler._openListeners,
+                    queueItem.url,
+                    queueItem.status,
+                    queueItem.fetched,
+                    queueItem.stateData.code,
+                    queueItem.referrer
                 );
             });
         });

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -3,9 +3,6 @@ const https = require('https');
 
 const Crawler = require('simplecrawler');
 
-let crawlStarts = 0;
-let crawlStops = 0;
-
 const {
     newEmptyAnalysis,
     newEmptyAnalyses,
@@ -119,6 +116,7 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
     crawler.on('fetch404', fetchCompleted);
     crawler.on('fetch410', fetchCompleted);
     crawler.on('fetcherror', fetchCompleted);
+
     crawler.on('fetchprevented', (queueItem) =>
         console.log(`fetch for url=${queueItem.url} prevented by the rules`)
     );
@@ -131,14 +129,7 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
         console.log(`fetch for url=${queueItem.url} client fetch error: ${error}`)
     );
 
-    crawler.on('crawlstart', () => {
-        crawlStarts += 1;
-    });
-
-    crawler.on('complete', () => {
-        crawlStops += 1;
-        crawlCompleted;
-    });
+    crawler.on('complete', crawlCompleted);
 
     const originalEmit = crawler.emit;
     crawler.emit = function (evtName, queueItem) {

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -44,8 +44,13 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
 
     const skipUrls = (variables.skipUrls || []).map((str) => new RegExp(str));
     crawler.addFetchCondition((queueItem, referrerQueueItem, callback) => {
-        const fetch = !skipUrls.some((skipUrl) => skipUrl.test(queueItem.url));
-        callback(null, fetch);
+        if (queueItem === referrerQueueItem) {
+            const fetch = false
+            callback(null, fetch)
+        } else {
+            const fetch = !skipUrls.some((skipUrl) => skipUrl.test(queueItem.url));
+            callback(null, fetch);
+        }
     });
 
     const header = new Set();

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -128,7 +128,15 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
         console.log(`fetch for url=${queueItem.url} client fetch error: ${error}`)
     );
 
-    crawler.on('crawlstart', () => console.log(crawler.initialURL));
+    crawler.on('crawlstart', () => {
+        console.log(crawler.initialURL);
+    });
+
+    crawler.on('discoverycomplete', () => {
+        console.log('____________');
+        console.log(crawler.queue);
+        console.log('____________');
+    });
 
     const originalEmit = crawler.emit;
     crawler.emit = function (evtName, queueItem) {

--- a/src/crawler/crawlPath.js
+++ b/src/crawler/crawlPath.js
@@ -128,7 +128,7 @@ module.exports = (fullPath, maxDepth, variables, checkers, done) => {
         console.log(`fetch for url=${queueItem.url} client fetch error: ${error}`)
     );
 
-    crawler.on('crawlstart', (queueItem) => console.log(queueItem));
+    crawler.on('crawlstart', console.log(crawler.initialURL));
 
     const originalEmit = crawler.emit;
     crawler.emit = function (evtName, queueItem) {


### PR DESCRIPTION
- Fix for bug that produced timeouts in CI. The tests would run, finish successfully, but CI would not receive an exit code. 
- The bug occured when the crawler encountered URLs that were also crawl starting points. 
- The above scenario caused SimpleCrawler to send multiple, erroneous 'crawlstart' events, which did not finish, leading to CI to force a timeout. 
- A new condition was introduced to SimpleCrawler's behaviour for when it's trying to add into its queue a URL that is an initiator - that specific URL is removed forcefully from the queue. 
- SimpleCrawler was also made verbose so that we have a better overview of what it's doing in CI.